### PR TITLE
fixes #6: ignore "window close" events when they mean tabs

### DIFF
--- a/Swift Quit/SwiftQuit.swift
+++ b/Swift Quit/SwiftQuit.swift
@@ -115,6 +115,11 @@ class SwiftQuit {
     
     @objc class func activateAutomaticAppClosing(){
         swindler.on { (event: WindowDestroyedEvent) in
+            if !event.window.application.knownWindows.isEmpty {
+                print("Application still has windows; aborting")
+                return
+            }
+
             let processIdentifier = event.window.application.processIdentifier
             closeApplication(pid:processIdentifier)
         }


### PR DESCRIPTION
This double-checks that an app doesn't have any more windows when a "window destroyed" event is received, which apparently is also triggered for tabs (reported upstream at https://github.com/tmandry/Swindler/issues/93), before quitting the app. 