### PR TITLE
fixes #3: quit apps after 2 seconds delay

### DIFF
--- a/Swift Quit/SwiftQuit.swift
+++ b/Swift Quit/SwiftQuit.swift
@@ -116,11 +116,11 @@ class SwiftQuit {
     @objc class func activateAutomaticAppClosing(){
         swindler.on { (event: WindowDestroyedEvent) in
             let processIdentifier = event.window.application.processIdentifier
-            closeApplication(pid:processIdentifier)
+            closeApplication(pid:processIdentifier, eventApp:event.window.application)
         }
     }
     
-    @objc class func closeApplication(pid:Int32){
+    class func closeApplication(pid:Int32, eventApp:Swindler.Application){
         let myAppPid = ProcessInfo.processInfo.processIdentifier
 
         let app = AppKit.NSRunningApplication.init(processIdentifier: pid)!
@@ -143,27 +143,12 @@ class SwiftQuit {
                 if(swiftQuitSettings["quitWhen"] == "anyWindowClosed"){
                     app.terminate()
                 }
-                else{
-
-                    var openWindows = 0
-                    if let windowList = CGWindowListCopyWindowInfo(.optionOnScreenOnly, kCGNullWindowID) as? [[ String : Any]]{
-                        
-                        for window in windowList {
-                            if let windowName = window[kCGWindowOwnerName as String] as? String {
-                                //print(windowName)
-                                if windowName == app.localizedName!{
-                                    openWindows += 1
-                                    //closeApp = false
-                                }
-                            }
+                else {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(2)) {
+                        if eventApp.knownWindows.isEmpty {
+                            app.terminate()
                         }
                     }
-                    
-
-                    if(openWindows == 1){
-                        app.terminate()
-                    }
-                
                 }
                 
             }


### PR DESCRIPTION
There are a multitude of ways to accomplish this, but I thought this one was the simplest. 

The current code checks in `closeApplication()` that the app in question has "one window", which really means that it just closed its last window. 

The new code just uses the same app object that received the window destroy event (passing it) and checks it after two seconds to make sure it doesn't have any windows _now_. This allows the user to, say, reopen a window for the app after closing the last one, as long as it is inside of two seconds. 

Two seconds seems fair to avoid any problems with, say, re-launching a manually quit app. 

This also requires removing `@objc` from `closeApplication()`, where it's not clear why that was there in the first place anyway. 